### PR TITLE
Es necesario incluir el "response" en el callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ KeyCDN.prototype._call = function(url, method, data, callback) {
 		if (!error && !!data.status && data.status !== 'success') {
 			error = new Error(data.description || data.error_message);
 		}
-		callback(error, data || {});
+		callback(error, data || {}, response);
 	}).auth(this.apiKey, '');
 };
 


### PR DESCRIPTION
Para tener el control del consumo de la api es necesario tener las cabeceras en el callback.
