### PR TITLE
update request dependency to use latest 2.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/keycdn/node-keycdn-api/issues"
   },
   "dependencies": {
-    "request": "~2.55.0"
+    "request": "2.x.x"
   },
   "devDependencies": {
     "tape": "~2.3.0",


### PR DESCRIPTION
This updates the dependency for request to always use latest 2. Before it was fixed to 2.55.x therefore in was never updated in projects depending on this package leaving code with vulnerabilities running.